### PR TITLE
Added German Email support

### DIFF
--- a/Duckling/Email/DE/Corpus.hs
+++ b/Duckling/Email/DE/Corpus.hs
@@ -1,0 +1,62 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+-- of patent rights can be found in the PATENTS file in the same directory.
+
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Duckling.Email.DE.Corpus
+  ( corpus
+  , negativeCorpus
+  ) where
+
+import Data.String
+import Prelude
+import qualified Data.Text as Text
+
+import Duckling.Email.Types
+import Duckling.Locale
+import Duckling.Resolve
+import Duckling.Testing.Types
+
+negativeCorpus :: NegativeCorpus
+negativeCorpus = (testContext { locale = makeLocale DE Nothing }, testOptions, examples)
+  where
+    examples =
+      [ "fitness at 6.40"
+      , "class at 12.00"
+      , "tonight at 9.15"
+      , " dot 2@abci"
+      , "x@ dot x"
+      , "x@ x dot "
+      , "abc@x dot "
+      , Text.replicate 10000 "a at a"
+      ]
+
+corpus :: Corpus
+corpus = (testContext { locale = makeLocale DE Nothing }, testOptions, allExamples)
+
+allExamples :: [Example]
+allExamples = concat
+  [ examples (EmailData "alice@exAmple.io")
+             [ "alice at exAmple.io"
+             ]
+  , examples (EmailData "yo+yo@blah.org")
+             [ "yo+yo at blah.org"
+             ]
+  , examples (EmailData "1234+abc@x.net")
+             [ "1234+abc at x.net"
+             ]
+  , examples (EmailData "jean-jacques@stuff.co.uk")
+             [ "jean-jacques at stuff.co.uk"
+             ]
+  , examples (EmailData "asdf+ab.c@gmail.com")
+             [ "asdf+ab punkt c at gmail punkt com"
+             ]
+  , examples (EmailData "asdf.k@fb.com")
+             [ "asdf punkt k@fb punkt com"
+             ]
+  ]

--- a/Duckling/Email/DE/Rules.hs
+++ b/Duckling/Email/DE/Rules.hs
@@ -1,0 +1,42 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in the
+-- LICENSE file in the root directory of this source tree. An additional grant
+-- of patent rights can be found in the PATENTS file in the same directory.
+
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Duckling.Email.DE.Rules
+  ( rules ) where
+
+import Data.String
+import Prelude
+import qualified Data.Text as Text
+
+import Duckling.Dimensions.Types
+import Duckling.Email.Types (EmailData (..))
+import Duckling.Regex.Types
+import Duckling.Types
+import qualified Duckling.Email.Types as TEmail
+
+ruleEmailSpelledOut :: Rule
+ruleEmailSpelledOut = Rule
+  { name = "email spelled out"
+  , pattern =
+    [ regex "([\\w_+-]+(?:(?: punkt |\\.)[\\w_+-]+){0,10})(?: at |@)([a-zA-Z]+(?:(?:\\.| punkt )[\\w_-]+){1,10})"
+    ]
+  , prod = \xs -> case xs of
+      (Token RegexMatch (GroupMatch (m1:m2:_)):_) ->
+        Just $ Token Email EmailData
+          { TEmail.value = Text.concat [replaceDots m1, "@", replaceDots m2] }
+        where replaceDots = Text.replace " punkt " "."
+      _ -> Nothing
+  }
+
+rules :: [Rule]
+rules =
+  [ ruleEmailSpelledOut
+  ]

--- a/Duckling/Rules/DE.hs
+++ b/Duckling/Rules/DE.hs
@@ -19,6 +19,7 @@ import Duckling.Dimensions.Types
 import Duckling.Locale
 import Duckling.Types
 import qualified Duckling.Duration.DE.Rules as Duration
+import qualified Duckling.Email.DE.Rules as Email
 import qualified Duckling.Ordinal.DE.Rules as Ordinal
 import qualified Duckling.Numeral.DE.Rules as Numeral
 import qualified Duckling.Time.DE.Rules as Time
@@ -35,7 +36,7 @@ langRules :: Some Dimension -> [Rule]
 langRules (This AmountOfMoney) = []
 langRules (This Distance) = []
 langRules (This Duration) = Duration.rules
-langRules (This Email) = []
+langRules (This Email) = Email.rules
 langRules (This Numeral) = Numeral.rules
 langRules (This Ordinal) = Ordinal.rules
 langRules (This PhoneNumber) = []

--- a/duckling.cabal
+++ b/duckling.cabal
@@ -329,6 +329,8 @@ library
                      , Duckling.Duration.Types
 
                      -- Email
+                     , Duckling.Email.DE.Corpus
+                     , Duckling.Email.DE.Rules
                      , Duckling.Email.EN.Corpus
                      , Duckling.Email.EN.Rules
                      , Duckling.Email.FR.Corpus


### PR DESCRIPTION
Added support for parsing email addresses written out in German. Essentially very similar to addresses written out in English except "dot" becomes "punkt".